### PR TITLE
fix: persist login and phone during registration

### DIFF
--- a/src/bot/bot.module.ts
+++ b/src/bot/bot.module.ts
@@ -9,12 +9,15 @@ import { BotContext } from 'src/types';
 import { UserModule } from 'src/user/user.module';
 import { FinanceModule } from 'src/finance/finance.module';
 import { createRegisterWizard } from './wizard';
+import { UserService } from 'src/user/user.service';
 
 @Module({
   imports: [
     TelegrafModule.forRootAsync({
-      useFactory: () => {
-        const stage = new Scenes.Stage<BotContext>([createRegisterWizard()]);
+      useFactory: (botService: BotService, userService: UserService) => {
+        const stage = new Scenes.Stage<BotContext>([
+          createRegisterWizard(userService, botService),
+        ]);
 
         return {
           token: process.env.BOT_TOKEN as string,
@@ -28,6 +31,7 @@ import { createRegisterWizard } from './wizard';
           ],
         };
       },
+      inject: [BotService, UserService],
     }),
     UserModule,
     FinanceModule,

--- a/src/bot/bot.service.ts
+++ b/src/bot/bot.service.ts
@@ -3,7 +3,7 @@ import { Context, Markup } from 'telegraf';
 import { WizardScene, Stage } from 'telegraf/scenes';
 import { UserService } from '../user/user.service';
 import { RoleEnum } from 'src/enums';
-import { BotContext, RegisterWizardContext } from 'src/types';
+import { BotContext } from 'src/types';
 import { commands } from 'src/config';
 import { FinanceService } from 'src/finance/finance.service';
 import { deleteMessageWithDelay, formatDate } from 'src/utils';
@@ -97,8 +97,8 @@ export class BotService {
     await ctx.reply(message);
   }
 
-  registerWizard(): WizardScene<RegisterWizardContext> {
-    return new WizardScene<RegisterWizardContext>(
+  registerWizard(): WizardScene<BotContext> {
+    return new WizardScene<BotContext>(
       'REGISTER_WIZARD',
       async (ctx) => {
         const sentMessage = await ctx.reply(
@@ -186,9 +186,9 @@ export class BotService {
     );
   }
 
-  setupScenes(): Stage<RegisterWizardContext> {
+  setupScenes(): Stage<BotContext> {
     const registerScene = this.registerWizard();
-    const stage = new Stage<RegisterWizardContext>([registerScene]);
+    const stage = new Stage<BotContext>([registerScene]);
 
     return stage;
   }

--- a/src/bot/wizard.ts
+++ b/src/bot/wizard.ts
@@ -1,20 +1,51 @@
-// src/bot/registerWizardScene.ts
 import { Scenes } from 'telegraf';
-import { RegisterWizardContext } from 'src/types';
+import { BotContext } from 'src/types';
+import { UserService } from 'src/user/user.service';
+import { BotService } from './bot.service';
 
-export function createRegisterWizard(): Scenes.WizardScene<RegisterWizardContext> {
-  return new Scenes.WizardScene<RegisterWizardContext>(
+export function createRegisterWizard(
+  userService: UserService,
+  botService: BotService,
+): Scenes.WizardScene<BotContext> {
+  return new Scenes.WizardScene<BotContext>(
     'REGISTER_WIZARD',
     async (ctx) => {
       await ctx.reply('📝 Введите логин:');
       return ctx.wizard.next();
     },
     async (ctx) => {
-      await ctx.reply('📞 Введите номер телефона:');
+      if (!ctx.message || !('text' in ctx.message)) {
+        await ctx.reply('❌ Пожалуйста, введите логин текстом.');
+        return;
+      }
+      ctx.wizard.state.login = ctx.message.text.trim();
+      await ctx.reply(
+        '📞 Введите номер телефона или отправьте контакт:',
+      );
       return ctx.wizard.next();
     },
     async (ctx) => {
+      if (!ctx.message) {
+        await ctx.reply('❌ Ошибка! Пожалуйста, отправьте номер.');
+        return;
+      }
+
+      let phoneNumber: string | undefined;
+      if ('contact' in ctx.message) {
+        phoneNumber = ctx.message.contact.phone_number;
+      } else if ('text' in ctx.message) {
+        phoneNumber = ctx.message.text.trim();
+      }
+
+      await userService.saveUserData(ctx, {
+        login: ctx.wizard.state.login,
+        phone: phoneNumber,
+        isRegistered: true,
+      });
+
       await ctx.reply('✅ Регистрация завершена!');
+      await botService.showMenu(ctx);
+
       return ctx.scene.leave();
     },
   );

--- a/src/bot/wizard.ts
+++ b/src/bot/wizard.ts
@@ -9,11 +9,11 @@ export function createRegisterWizard(
 ): Scenes.WizardScene<BotContext> {
   return new Scenes.WizardScene<BotContext>(
     'REGISTER_WIZARD',
-    async (ctx) => {
+    async (ctx: BotContext) => {
       await ctx.reply('📝 Введите логин:');
       return ctx.wizard.next();
     },
-    async (ctx) => {
+    async (ctx: BotContext) => {
       if (!ctx.message || !('text' in ctx.message)) {
         await ctx.reply('❌ Пожалуйста, введите логин текстом.');
         return;
@@ -24,7 +24,7 @@ export function createRegisterWizard(
       );
       return ctx.wizard.next();
     },
-    async (ctx) => {
+    async (ctx: BotContext) => {
       if (!ctx.message) {
         await ctx.reply('❌ Ошибка! Пожалуйста, отправьте номер.');
         return;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,28 +1,18 @@
 import { Scenes } from 'telegraf';
 
-interface RegisterWizardState extends Scenes.WizardSessionData {
+interface RegisterWizardState {
   login?: string;
   phone?: string;
 }
 
-export type RegisterWizardContext = Scenes.WizardContext & {
-  wizard: Scenes.WizardSession<RegisterWizardState>;
-};
-
-interface SessionData {
+interface BotSession extends Scenes.WizardSessionData {
+  state: RegisterWizardState;
   [x: string]: number | undefined;
   waitingFor?: 'login' | 'phone' | 'search_user' | 'confirm_amount' | null;
   waitingForPayment?: number | null;
   paymentAmount?: number | null;
 }
 
-// export interface BotContext extends Context {
-//   match?: RegExpMatchArray;
-//   session: SessionData;
-// }
-
-export type BotContext = Scenes.WizardContext<RegisterWizardState> & {
-  session: BotSession;
+export interface BotContext extends Scenes.WizardContext<BotSession> {
   match?: RegExpMatchArray;
-  scene: Scenes.SceneContextScene<BotContext, Scenes.WizardSessionData>;
-};
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -5,11 +5,18 @@ interface RegisterWizardState {
   phone?: string;
 }
 
-interface BotSession extends Scenes.WizardSessionData {
+export interface BotSession extends Scenes.WizardSessionData {
   state: RegisterWizardState;
-  [x: string]: number | undefined;
-  waitingFor?: 'login' | 'phone' | 'search_user' | 'confirm_amount' | null;
+  waitingFor?:
+    | 'login'
+    | 'phone'
+    | 'search_user'
+    | 'confirm_amount'
+    | 'selecting_transaction'
+    | 'confirm_receving'
+    | null;
   waitingForPayment?: number | null;
+  waitingForTransaction?: number | null;
   paymentAmount?: number | null;
 }
 


### PR DESCRIPTION
## Summary
- save user login and phone during the registration wizard
- configure Telegraf stage with injected services to enable persistence

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d84f8e89c832292368deec3cef325